### PR TITLE
feat: Image reuse 镜像复用

### DIFF
--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -3,9 +3,6 @@ name: base
 on:
   workflow_dispatch:
 
-env:
-  REGISTRY_IMAGE: initialencounter/llonebot-docker:base
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,22 +13,12 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      -
-        name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - 
+        name: Set Tag Name
+        run: echo "TAG_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -45,65 +32,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push by digest
-        id: build
+        name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: ./base/.
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      -
-        name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      -
-        name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      -
-        name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-      -
-        name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          push: true
+          tags: initialencounter/llonebot-docker:base

--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -49,7 +49,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v5
         with:
-          context: ./base.
+          context: ./base/.
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -3,6 +3,9 @@ name: base
 on:
   workflow_dispatch:
 
+env:
+  REGISTRY_IMAGE: initialencounter/llonebot-docker-base
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,12 +16,22 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      - 
-        name: Set Tag Name
-        run: echo "TAG_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -32,9 +45,65 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: ./base/.
-          push: true
-          tags: initialencounter/llonebot-docker:base
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -1,4 +1,4 @@
-name: ci
+name: base
 
 on:
   workflow_dispatch:

--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: mlikiowa/llonebot-docker:base
+  REGISTRY_IMAGE: initialencounter/llonebot-docker:base
 
 jobs:
   build:

--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: initialencounter/llonebot-docker
+  REGISTRY_IMAGE: mlikiowa/llonebot-docker
 
 jobs:
   build:

--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: initialencounter/llonebot-docker
+  REGISTRY_IMAGE: mlikiowa/llonebot-docker:base
 
 jobs:
   build:
@@ -49,7 +49,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./base.
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: initialencounter/llonebot-docker-base
+  REGISTRY_IMAGE: initialencounter/llonebot-docker
 
 jobs:
   build:
@@ -31,7 +31,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+                type=raw,value=base,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -90,7 +90,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+                type=raw,value=base,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
       -
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,9 @@ name: ci
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "main"
 
 env:
   REGISTRY_IMAGE: mlikiowa/llonebot-docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: initialencounter/llonebot-docker
+  REGISTRY_IMAGE: mlikiowa/llonebot-docker
 
 jobs:
   build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: ci
+name: latest
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,9 +3,6 @@ name: latest
 on:
   workflow_dispatch:
 
-env:
-  REGISTRY_IMAGE: initialencounter/llonebot-docker
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,22 +13,12 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      -
-        name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - 
+        name: Set Tag Name
+        run: echo "TAG_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -45,65 +32,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push by digest
-        id: build
+        name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      -
-        name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      -
-        name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      -
-        name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-      -
-        name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          context: ./base/.
+          push: true
+          tags: initialencounter/llonebot-docker:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,10 @@
-name: latest
+name: ci
 
 on:
   workflow_dispatch:
+
+env:
+  REGISTRY_IMAGE: initialencounter/llonebot-docker
 
 jobs:
   build:
@@ -13,12 +16,22 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      - 
-        name: Set Tag Name
-        run: echo "TAG_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
         name: Checkout
         uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -32,9 +45,65 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
-          context: ./base/.
-          push: true
-          tags: initialencounter/llonebot-docker:latest
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+                type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM initialencounter/llonebot-docker:base
+FROM initialencounter/llonebot-docker-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV VNC_PASSWD=vncpasswd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM initialencounter/llonebot-docker-base
+FROM initialencounter/llonebot-docker:base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV VNC_PASSWD=vncpasswd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM initialencounter/llonebot-docker:base
+FROM mlikiowa/llonebot-docker:base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV VNC_PASSWD=vncpasswd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,9 @@
-FROM ubuntu:22.04
+FROM initialencounter/llonebot-docker:base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV VNC_PASSWD=vncpasswd
 
-RUN apt-get update && apt-get install -y \
-    openbox \
-    xorg \
-    dbus-user-session \
-    openbox \
-    curl \
-    unzip \
-    x11vnc \
-    xvfb \
-    fluxbox \
-    supervisor \
-    libnotify4 \
-    libnss3 \
-    xdg-utils \
-    libsecret-1-0 \
-    ffmpeg \
-    libgbm1 \
-    libasound2 \
-    fonts-wqy-zenhei \
-    git \
-    gnutls-bin && \    
-    apt-get clean --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/* && \
-    # 安装NoVnc
-    \
-    git config --global http.sslVerify false && git config --global http.postBuffer 1048576000 && \
-    cd /opt && git clone https://github.com/novnc/noVNC.git && \
-    cd /opt/noVNC/utils && git clone https://github.com/novnc/websockify.git && \
-    cp /opt/noVNC/vnc.html /opt/noVNC/index.html   && \
-    \
-    # 安装QQ
-    arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
+RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     curl -o /root/linuxqq.deb https://dldir1.qq.com/qqfile/qq/QQNT/852276c1/linuxqq_3.2.5-21453_${arch}.deb && \
     dpkg -i /root/linuxqq.deb && apt-get -f install -y && rm /root/linuxqq.deb && \
     # 安装LiteLoader

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV VNC_PASSWD=vncpasswd
+
+RUN apt-get update && apt-get install -y \
+    openbox \
+    xorg \
+    dbus-user-session \
+    openbox \
+    curl \
+    unzip \
+    x11vnc \
+    xvfb \
+    fluxbox \
+    supervisor \
+    libnotify4 \
+    libnss3 \
+    xdg-utils \
+    libsecret-1-0 \
+    ffmpeg \
+    libgbm1 \
+    libasound2 \
+    fonts-wqy-zenhei \
+    git \
+    gnutls-bin && \    
+    apt-get clean --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/* && \
+    # 安装NoVnc
+    \
+    git config --global http.sslVerify false && git config --global http.postBuffer 1048576000 && \
+    cd /opt && git clone https://github.com/novnc/noVNC.git && \
+    cd /opt/noVNC/utils && git clone https://github.com/novnc/websockify.git && \
+    cp /opt/noVNC/vnc.html /opt/noVNC/index.html
+
+    


### PR DESCRIPTION
新建一个基础镜像的 tag，`mlikiowa/llonebot-docker:base`
在此镜像安装部分依赖（这部分依赖不需要经常更新）

最终镜像只需要在 `mlikiowa/llonebot-docker:base` 的基础上构建即可

它具有以下优势

- 对于开发者，这将减少构建时间

 - 对于用户，在更新镜像时，不需要拉取全部镜像层，只需拉去部分更新的镜像层，减少更新时间

workflows 已经过测试，[action](https://github.com/initialencounter/llonebot-docker/actions/runs/8263140734), [hub.docker](https://hub.docker.com/r/initialencounter/llonebot-docker)